### PR TITLE
Refactor to avoid features mingling, and some bug fixs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -158,6 +158,7 @@ impl ServerConfig {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct OpenIdConfig {
     pub(crate) issuer_url: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,10 +39,7 @@ pub enum Error {
     Git(git2::Error),
     #[error("argon2 error: {}", _0)]
     Argon2(argon2::Error),
-    #[cfg(all(
-        any(feature = "db-mongo", feature = "crates-io-mirroring"),
-        not(all(feature = "db-sled", feature = "db-redis"))
-    ))]
+    #[cfg(any(feature = "openid"))]
     #[error("Openid error: {}", _0)]
     OpenId(String),
     #[error("URL parsing error: {}", _0)]
@@ -85,6 +82,7 @@ pub enum Error {
     InvalidCrateName(String),
     #[error("invalid token: {}", _0)]
     InvalidToken(String),
+    #[cfg(feature = "openid")]
     #[error("invalid csrf state: {}", _0)]
     InvalidCsrfToken(String),
     #[error("invalid user id: {}", _0)]

--- a/src/openid.rs
+++ b/src/openid.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "openid")]
+
 use crate::config::OpenIdConfig;
 use crate::db_manager::DbManager;
 use crate::error::Error;
@@ -252,14 +253,22 @@ async fn get_openid_client(
     ))
 }
 
-#[tracing::instrument(skip(openid_config, id_token, userinfo))]
+#[tracing::instrument(skip(openid_config, _id_token, userinfo))]
 fn check_user_authorization<GC: openidconnect::GenderClaim>(
     openid_config: Arc<OpenIdConfig>,
-    id_token: &CoreIdTokenClaims,
+    _id_token: &CoreIdTokenClaims,
     userinfo: &UserInfoClaims<Claims, GC>,
 ) -> bool {
-    if openid_config.gitlab_authorized_users.is_none()
-        && openid_config.gitlab_authorized_groups.is_none()
+    if openid_config
+        .gitlab_authorized_users
+        .as_ref()
+        .map(Vec::is_empty)
+        .unwrap_or(true)
+        && openid_config
+            .gitlab_authorized_groups
+            .as_ref()
+            .map(Vec::is_empty)
+            .unwrap_or(true)
     {
         tracing::info!("no openid config authorization restrictions, authorizing.");
         return true;


### PR DESCRIPTION
1. refactor `openid` feature to avoid minglign with `crates-io-mirroring`. 
  
    Current implementation mingles `openid` feature with `crates-io-mirroring`,  which can certainly work, but in the future it can be really hard to maintain when more features adding in. Now 4 functions is written to handle different case for two features, then what if we have dozens of features? 

    ```rust
    #[cfg(all(feature = "crates-io-mirroring", feature = "openid"))]
    fn apis(...) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone;

    #[cfg(all(not(feature = "crates-io-mirroring"), feature = "openid"))]
    fn apis(...) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone;

    #[cfg(all(feature = "crates-io-mirroring", not(feature = "openid")))]
    fn apis(...) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone;

    #[cfg(all(not(feature = "crates-io-mirroring"), not(feature = "openid")))]
    fn apis(...) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone;
    ```

    Actually, current implementation does not handle feature conflicts correctly, that disable `crates-io-mirroring` feature can actually fail the cargo build. 

2. fix a some minor bug that disallow any user to publish when authorized_users and authorized_groups is `Some(vec![])`.